### PR TITLE
Preserve stacktrace when catching, and then throwing something else

### DIFF
--- a/lwjgl/src/main/java/org/spout/renderer/lwjgl/gl20/GL20Context.java
+++ b/lwjgl/src/main/java/org/spout/renderer/lwjgl/gl20/GL20Context.java
@@ -67,7 +67,7 @@ public class GL20Context extends Context {
             }
             Display.create(pixelFormat, createContextAttributes());
         } catch (LWJGLException ex) {
-            throw new IllegalStateException("Unable to create OpenGL context: " + ex.getMessage());
+            throw new IllegalStateException("Unable to create OpenGL. ", ex);
         }
         // Check for errors
         LWJGLUtil.checkForGLError();


### PR DESCRIPTION
when creating a GL Context.
