### PR TITLE
Update pom.xml

### DIFF
--- a/lwjgl/pom.xml
+++ b/lwjgl/pom.xml
@@ -27,7 +27,7 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>caustic-api</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
+			<scope>compile</scope>
 		</dependency>
 		<!-- Include in final JAR -->
 		<dependency>


### PR DESCRIPTION
LWJGL has to have API included. In my project, I have to add a dependency for LWJGL and API for it to work properly which doesn't make sense. If I have LWJGL, I should have the API it implements.
